### PR TITLE
Added the Python API version of the PDL notebook to the CI tests 

### DIFF
--- a/.github/notebook_lists/pdl_notebooks.txt
+++ b/.github/notebook_lists/pdl_notebooks.txt
@@ -1,0 +1,1 @@
+recipes/PDL/Prompt_Declaration_Language_python.ipynb

--- a/.github/notebook_lists/vanilla_notebooks.txt
+++ b/.github/notebook_lists/vanilla_notebooks.txt
@@ -4,3 +4,4 @@ recipes/Summarize/Summarize.ipynb
 recipes/RAG/RAG_with_Langchain.ipynb
 recipes/Granite_Guardian/HAP.ipynb
 recipes/Entity-Extraction/entity_extraction.ipynb
+recipes/PDL/Prompt_Declaration_Language_python.ipynb

--- a/.github/notebook_lists/vanilla_notebooks.txt
+++ b/.github/notebook_lists/vanilla_notebooks.txt
@@ -4,4 +4,3 @@ recipes/Summarize/Summarize.ipynb
 recipes/RAG/RAG_with_Langchain.ipynb
 recipes/Granite_Guardian/HAP.ipynb
 recipes/Entity-Extraction/entity_extraction.ipynb
-recipes/PDL/Prompt_Declaration_Language_python.ipynb

--- a/.github/workflows/pdl_workflow.yaml
+++ b/.github/workflows/pdl_workflow.yaml
@@ -4,27 +4,15 @@ on:
   push:
     branches:
       - main
-      - pm-143
     paths:
-      - 'recipes/Function-Calling/Function_Calling.ipynb'
-      - 'recipes/RAG/RAG_with_Langchain.ipynb'
-      - 'recipes/Entity-Extraction/entity_extraction.ipynb'
-      - 'recipes/Granite_Guardian/HAP.ipynb'
-      - '.github/notebook_lists/vanilla_notebooks.txt'
-      - 'recipes/AI-Agents/Agentic_RAG.ipynb'
-      - 'recipes/Summarize/Summarize.ipynb'
+      - 'recipes/PDL/Prompt_Declaration_Language_python.ipynb'
+      - '.github/notebook_lists/pdl_notebooks.txt'
   pull_request:
     branches:
       - main
-      - pm-143
     paths:
-      - 'recipes/Function-Calling/Function_Calling.ipynb'
-      - '.github/workflows/vanilla_workflow.yaml'
-      - 'recipes/RAG/RAG_with_Langchain.ipynb'
-      - 'recipes/Entity-Extraction/entity_extraction.ipynb'
-      - 'recipes/Granite_Guardian/HAP.ipynb'
-      - 'recipes/AI-Agents/Agentic_RAG.ipynb'
-      - 'recipes/Summarize/Summarize.ipynb'
+      - 'recipes/PDL/Prompt_Declaration_Language_python.ipynb'
+      - '.github/workflows/pdl_workflow.yaml'
 
 jobs:
   test-vanilla-notebooks:
@@ -37,7 +25,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/pdl_workflow.yaml
+++ b/.github/workflows/pdl_workflow.yaml
@@ -40,7 +40,7 @@ jobs:
           WATSONX_PROJECT_ID: ${{ secrets.WATSONX_PROJECT_ID }}
           WATSONX_URL: ${{ secrets.WATSONX_URL }}
         run: |
-          notebooks=$(cat .github/notebook_lists/vanilla_notebooks.txt | grep -v '^#' | tr '\n' ' ')  
+          notebooks=$(cat .github/notebook_lists/pdl_notebooks.txt | grep -v '^#' | tr '\n' ' ')  
           for notebook in $notebooks; do  
             echo "Executing $notebook"  
             jupyter nbconvert --to notebook --execute --inplace $notebook  

--- a/.github/workflows/pdl_workflow.yaml
+++ b/.github/workflows/pdl_workflow.yaml
@@ -40,6 +40,7 @@ jobs:
           WATSONX_PROJECT_ID: ${{ secrets.WATSONX_PROJECT_ID }}
           WATSONX_URL: ${{ secrets.WATSONX_URL }}
         run: |
+          set -e
           notebooks=$(cat .github/notebook_lists/pdl_notebooks.txt | grep -v '^#' | tr '\n' ' ')  
           for notebook in $notebooks; do  
             echo "Executing $notebook"  

--- a/.github/workflows/pdl_workflow.yaml
+++ b/.github/workflows/pdl_workflow.yaml
@@ -1,4 +1,4 @@
-name: CI for Vanilla Notebooks
+name: CI for PDL Notebooks
 
 on:
   push:
@@ -15,7 +15,7 @@ on:
       - '.github/workflows/pdl_workflow.yaml'
 
 jobs:
-  test-vanilla-notebooks:
+  test-pdl-notebooks:
     runs-on: ubuntu-latest
 
     steps:
@@ -32,7 +32,7 @@ jobs:
           python -m pip install --upgrade pip    
           pip install nbconvert nbclient ipykernel
 
-      - name: Run Vanilla Notebooks
+      - name: Run PDL Notebooks
         env:
           GRANITE_TESTING: ${{ vars.GRANITE_TESTING }}
           REPLICATE_API_TOKEN: ${{ secrets.REPLICATE_API_TOKEN }}

--- a/.github/workflows/vanilla_workflow.yaml
+++ b/.github/workflows/vanilla_workflow.yaml
@@ -13,6 +13,7 @@ on:
       - '.github/notebook_lists/vanilla_notebooks.txt'
       - 'recipes/AI-Agents/Agentic_RAG.ipynb'
       - 'recipes/Summarize/Summarize.ipynb'
+      - 'recipes/PDL/Prompt_Declaration_Language_python.ipynb'
   pull_request:
     branches:
       - main
@@ -25,6 +26,7 @@ on:
       - 'recipes/Granite_Guardian/HAP.ipynb'
       - 'recipes/AI-Agents/Agentic_RAG.ipynb'
       - 'recipes/Summarize/Summarize.ipynb'
+      - 'recipes/PDL/Prompt_Declaration_Language_python.ipynb'
 
 jobs:
   test-vanilla-notebooks:

--- a/.github/workflows/vanilla_workflow.yaml
+++ b/.github/workflows/vanilla_workflow.yaml
@@ -52,6 +52,7 @@ jobs:
           WATSONX_PROJECT_ID: ${{ secrets.WATSONX_PROJECT_ID }}
           WATSONX_URL: ${{ secrets.WATSONX_URL }}
         run: |
+          set -e
           notebooks=$(cat .github/notebook_lists/vanilla_notebooks.txt | grep -v '^#' | tr '\n' ' ')  
           for notebook in $notebooks; do  
             echo "Executing $notebook"  

--- a/README.md
+++ b/README.md
@@ -16,10 +16,12 @@ The "Recipes" in the Granite Snack Cookbook showcase the essential capabilities 
    <a target="_blank" href="https://colab.research.google.com/github/ibm-granite-community/granite-snack-cookbook/blob/main/recipes/RAG/RAG_with_Langchain.ipynb">
    <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
    </a>
-1. [Prompt Declaration Language](recipes/PDL/Prompt_Declaration_Language.ipynb)
-   <!-- <a target="_blank" href="https://colab.research.google.com/github/ibm-granite-community/granite-snack-cookbook/blob/main/recipes/PDL/Prompt_Declaration_Language.ipynb">
-   <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
-   </a> --> (Colab Support Coming Soon!!)
+1. Prompt Declaration Language (PDL)
+   1. [Notebook that uses the PDL Jupyter Extension](recipes/PDL/Prompt_Declaration_Language.ipynb) (Not compatible with Colab)
+   1. [Notebook that uses the PDL Python API](recipes/PDL/Prompt_Declaration_Language_python.ipynb) 
+      <!-- <a target="_blank" href="https://colab.research.google.com/github/ibm-granite-community/granite-snack-cookbook/blob/main/recipes/PDL/Prompt_Declaration_Language_python.ipynb">
+      <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
+      </a> --> (Not yet available in Colab, because the latter uses Python 3.10)
 1. [Function Calling](recipes/Function-Calling/Function_Calling.ipynb)
    <a target="_blank" href="https://colab.research.google.com/github/ibm-granite-community/granite-snack-cookbook/blob/main/recipes/Function-Calling/Function_Calling.ipynb">
    <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>

--- a/README.md
+++ b/README.md
@@ -16,12 +16,6 @@ The "Recipes" in the Granite Snack Cookbook showcase the essential capabilities 
    <a target="_blank" href="https://colab.research.google.com/github/ibm-granite-community/granite-snack-cookbook/blob/main/recipes/RAG/RAG_with_Langchain.ipynb">
    <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
    </a>
-1. Prompt Declaration Language (PDL)
-   1. [Notebook that uses the PDL Jupyter Extension](recipes/PDL/Prompt_Declaration_Language.ipynb) (Not compatible with Colab)
-   1. [Notebook that uses the PDL Python API](recipes/PDL/Prompt_Declaration_Language_python.ipynb) 
-      <!-- <a target="_blank" href="https://colab.research.google.com/github/ibm-granite-community/granite-snack-cookbook/blob/main/recipes/PDL/Prompt_Declaration_Language_python.ipynb">
-      <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
-      </a> --> (Not yet available in Colab, because the latter uses Python 3.10)
 1. [Function Calling](recipes/Function-Calling/Function_Calling.ipynb)
    <a target="_blank" href="https://colab.research.google.com/github/ibm-granite-community/granite-snack-cookbook/blob/main/recipes/Function-Calling/Function_Calling.ipynb">
    <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
@@ -34,10 +28,12 @@ The "Recipes" in the Granite Snack Cookbook showcase the essential capabilities 
    <a target="_blank" href="https://colab.research.google.com/github/ibm-granite-community/granite-snack-cookbook/blob/main/recipes/Granite_Guardian/Granite_Guardian_Quick_Start.ipynb">
    <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
    </a>
-1. [Prompt Declaration Language](recipes/PDL/Prompt_Declaration_Language.ipynb)
-   <!-- <a target="_blank" href="https://colab.research.google.com/github/ibm-granite-community/granite-snack-cookbook/blob/main/recipes/PDL/Prompt_Declaration_Language.ipynb">
-   <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
-   </a> --> (Colab Support Coming Soon!!)
+1. Prompt Declaration Language (PDL)
+   1. [Notebook that uses the PDL Jupyter Extension](recipes/PDL/Prompt_Declaration_Language.ipynb) (Not compatible with Colab)
+   1. [Notebook that uses the PDL Python API](recipes/PDL/Prompt_Declaration_Language_python.ipynb) 
+      <!-- <a target="_blank" href="https://colab.research.google.com/github/ibm-granite-community/granite-snack-cookbook/blob/main/recipes/PDL/Prompt_Declaration_Language_python.ipynb">
+      <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
+      </a> --> (Not yet available in Colab, because the latter uses Python 3.10)
 1. [Entity Extraction](recipes/Entity-Extraction/entity_extraction.ipynb)
    <a target="_blank" href="https://colab.research.google.com/github/ibm-granite-community/granite-snack-cookbook/blob/main/recipes/Entity-Extraction/entity_extraction.ipynb">
    <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>

--- a/recipes/PDL/Prompt_Declaration_Language.ipynb
+++ b/recipes/PDL/Prompt_Declaration_Language.ipynb
@@ -23,7 +23,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! pip install 'prompt-declaration-language[examples]'"
+    "import sys\n",
+    "assert sys.version_info >= (3, 11) and sys.version_info <= (3, 12), f\"Use Python 3.11 or 3.12 to run this notebook.\""
    ]
   },
   {
@@ -33,12 +34,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "! pip install 'prompt-declaration-language[examples]'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "%load_ext pdl.pdl_notebook_ext"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "source": [
     "## Model Call\n",
@@ -51,7 +62,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,7 +78,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "source": [
     "## Model Chaining\n",
@@ -77,7 +88,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -91,7 +102,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "source": [
     "## Chat Templates\n",
@@ -104,7 +115,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -128,7 +139,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "source": [
     "### A closer look\n",
@@ -146,7 +157,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "source": [
     "## Data Pipeline\n",
@@ -159,7 +170,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -206,7 +217,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "source": [
     "## Conclusion\n",
@@ -234,7 +245,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.5"
+   "version": "3.11.10"
   }
  },
  "nbformat": 4,

--- a/recipes/PDL/Prompt_Declaration_Language_python.ipynb
+++ b/recipes/PDL/Prompt_Declaration_Language_python.ipynb
@@ -23,7 +23,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! pip install 'prompt-declaration-language[examples]'"
+    "import sys\n",
+    "assert sys.version_info >= (3, 11) and sys.version_info <= (3, 12), \\\n",
+    "    f\"Use Python 3.11 or 3.12 to run this notebook. You have {sys.version_info}\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! pip install 'prompt-declaration-language[examples]' "
    ]
   },
   {
@@ -98,7 +110,9 @@
     "\n",
     "The following example shows a full-fledged chatbot. In PDL, _roles_ are high level annotations and PDL takes care of applying the appropriate chat templates. This example illustrates the use of control structures such as the repeat-until block and reading from files or stdin with the read block. The chatbot repeatedly prompts the user for a query, which it submits to a model, and stops when the query is `quit`.\n",
     "\n",
-    "For your first query, type `What is APR?`. We'll discuss what happens to this string below."
+    "For your first query, type `What is APR?`. We'll discuss what happens to this string below.\n",
+    "\n",
+    "> **NOTE:** Because user input is required for this example, we don't run it when running our CI tests. That's the purpose of the `if os.environ.get('GRANITE_TESTING') is None:` check."
    ]
   },
   {
@@ -127,7 +141,11 @@
     "role: user\n",
     "\"\"\"\n",
     "\n",
-    "print(exec_str(pdl))"
+    "import os\n",
+    "if os.environ.get('GRANITE_TESTING') is None:\n",
+    "    print(exec_str(pdl))\n",
+    "else:\n",
+    "    print(\"Since this is the test environment, we skip running the chat example.\")"
    ]
   },
   {
@@ -244,7 +262,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.5"
+   "version": "3.11.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Also updated the README. There is a bug in the Python version of the notebook I'll file shortly. Also, it is not currently possible to run this notebook in Colab, because PDL requires Python 3.11 and Colab only supports 3.10.

### PR Checklist

- [x] **Commits signed**: All commits must be GPG or SSH signed.
- [x] **DCO Compliance**: Developer Certificate of Origin (DCO) applies to the code, documentation, and any example data provided. Ensure commits are signed off.
- [x] **Notebook outputs cleared**: Ensure all notebook outputs are cleared.
- [x] **Automated testing**: Add the recipe to the automated tests.
- [ ] **Test in Google Colab**:  **See note above!**
    - [ ] Test that it works in Google Colab (Python 3.10.12).
    - [ ] Colab has its own package set and Python version, so ensure compatibility.
- [x] **Test locally**:
    - [x] Ensure the code works in a fresh Python virtual environment (venv).
- [ ] **Flexible LLM platform support**:  **They hardcode their own API internally**
    - [ ] The platform should be easily switchable. Use LangChain for now.
    - [ ] Include `!pip install git+https://github.com/ibm-granite-community/granite-kitchen` in the instructions.
- [ ] **Example data**: Follow the example data guidance.
- [x] **README.md updates**:
    - [x] Add a link to the recipe in the Table of Contents (ToC).
    - [ ] Include a Colab button after that link. **Neither notebook is Colab compatible**
