### PR TITLE
Remove copy/edit mistake in the Python version of the PDL notebook.

### DIFF
--- a/recipes/PDL/Prompt_Declaration_Language_python.ipynb
+++ b/recipes/PDL/Prompt_Declaration_Language_python.ipynb
@@ -45,9 +45,7 @@
    "source": [
     "## Model Call\n",
     "\n",
-    "In PDL, the user specifies step-by-step the shape of data they want to generate. In the following, the `text` construct indicates a text block containing a prompt and a model call. Implicitly, PDL builds a background conversational context (list of role/content) which is used to make model calls. Each model call uses the context built so far as its input prompt.\n",
-    "\n",
-    "Note how the `%%pdl` magic makes it very concise to define what you want. (We'll explain the purpose of `--reset-context` shortly.)"
+    "In PDL, the user specifies step-by-step the shape of data they want to generate. In the following, the `text` construct indicates a text block containing a prompt and a model call. Implicitly, PDL builds a background conversational context (list of role/content) which is used to make model calls. Each model call uses the context built so far as its input prompt.\n"
    ]
   },
   {
@@ -77,7 +75,7 @@
    "metadata": {},
    "source": [
     "## Model Chaining\n",
-    "Model chaining, where the output of one model is used to query a second model (perhaps the same one), can be done by simply adding to the list of models to call declaratively. Since this cell has the `%%pdl` cell magic without the `--reset-context` option, it executes in the context created by the previous cell."
+    "Model chaining, where the output of one model is used to query a second model (perhaps the same one), can be done by simply adding to the list of models to call declaratively."
    ]
   },
   {


### PR DESCRIPTION
Fixes a copy and edit error, where the Python version of the PDL notebook referenced the `%%pdl` cell magic that is only used in the other version of this notebook, not this one.

_Only edits markdown comments; no code changes._

## PR Checklist

### Model Interaction

- [x] **Flexible LLM platform support** The platform should be easily switchable. Use LangChain or LlamaIndex.
- [x] **Use prompt guide corresponding to the model**  For example for [Granite 3.x Language Models](https://www.ibm.com/granite/docs/models/granite/#prompt-anatomy)

### Data

- [x] **Example data**: Follow the example data guidance.

### Notebook requirements

- [x] **Notebook outputs cleared**: Ensure all notebook outputs are cleared.
- [x] **Automated testing**: Add the recipe to the automated tests as described [here](https://github.com/ibm-granite-community/community/wiki/Automated-Validation)
- [ ] **Test in Google Colab**:
    - [ ] Test that it works in Google Colab (Python 3.10.12).
    - [ ] Colab has its own package set and Python version, so ensure compatibility.
- [ ] **Test locally**:
    - [ ] Ensure the code works in a fresh Python virtual environment (venv).
- [ ] **Standard access to secrets and variables** Include `!pip install git+https://github.com/ibm-granite-community/utils` in the first code cell in order to make `get_env_var` available to accessing secrets and variables in the recipe.

### Incoming References

- [ ] **README.md updates**:
    - [ ] Add a link to the recipe in the Table of Contents (ToC).
    - [ ] Include a Colab button after that link.

### GitHub

- [ ] **Commits signed**: All commits must be GPG or SSH signed.
- [ ] **DCO Compliance**: Developer Certificate of Origin (DCO) applies to the code, documentation, and any example data provided. Ensure commits are signed off.
