### PR TITLE
Cap pdl dependency to 0.3.x

### DIFF
--- a/recipes/PDL/Prompt_Declaration_Language.ipynb
+++ b/recipes/PDL/Prompt_Declaration_Language.ipynb
@@ -34,7 +34,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! pip install 'prompt-declaration-language[examples]'"
+    "! pip install 'prompt-declaration-language[examples]<0.4.0'"
    ]
   },
   {

--- a/recipes/PDL/Prompt_Declaration_Language_python.ipynb
+++ b/recipes/PDL/Prompt_Declaration_Language_python.ipynb
@@ -35,7 +35,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! pip install 'prompt-declaration-language[examples]'"
+    "! pip install 'prompt-declaration-language[examples]<0.4.0'"
    ]
   },
   {


### PR DESCRIPTION
The latest pdl release breaks the recipe. Something must be different in the yaml schema?

## PR Checklist

### GitHub

- [x] **Commits signed**: All commits must be GPG or SSH signed.
- [x] **DCO Compliance**: Developer Certificate of Origin (DCO) applies to the code, documentation, and any example data provided. Ensure commits are signed off.
