### PR TITLE
Free disk space

### DIFF
--- a/.github/workflows/notebooks.yaml
+++ b/.github/workflows/notebooks.yaml
@@ -102,6 +102,7 @@ jobs:
         3.11
       ref: ${{ needs.test_workflow_ready.outputs.ref }}
       all: ${{ fromJSON(needs.test_workflow_ready.outputs.all) }}
+      free-disk-space: '{"large-packages": false}'  # Takes a long time
 
   pdl:
     needs:
@@ -121,6 +122,7 @@ jobs:
         3.11
       ref: ${{ needs.test_workflow_ready.outputs.ref }}
       all: ${{ fromJSON(needs.test_workflow_ready.outputs.all) }}
+      free-disk-space: '{"large-packages": false}'  # Takes a long time
 
   test_workflow_complete:
     needs:


### PR DESCRIPTION
Sometimes we get errors about missing python packages which were pip installed but due to out-of-space errors are not actually installed.

## PR Checklist

### GitHub

- [x] **Commits signed**: All commits must be GPG or SSH signed.
- [x] **DCO Compliance**: Developer Certificate of Origin (DCO) applies to the code, documentation, and any example data provided. Ensure commits are signed off.
