### PR TITLE
Force a later version of docling

### DIFF
--- a/recipes/Agent-Communication-Protocol/Agent_Communication_Protocol.ipynb
+++ b/recipes/Agent-Communication-Protocol/Agent_Communication_Protocol.ipynb
@@ -53,7 +53,9 @@
    },
    "outputs": [],
    "source": [
-    "%pip install git+https://github.com/ibm-granite-community/utils \\\n",
+    "! echo \"::group::Install Dependencies\"\n",
+    "%pip install uv\n",
+    "! uv pip install git+https://github.com/ibm-granite-community/utils \\\n",
     "    acp-sdk \\\n",
     "    langchain_community \\\n",
     "    transformers \\\n",
@@ -63,7 +65,8 @@
     "    langchain_huggingface \\\n",
     "    faiss-cpu \\\n",
     "    ddgs \\\n",
-    "    docling"
+    "    'docling>=2.51.0'\n",
+    "! echo \"::endgroup::\""
    ]
   },
   {
@@ -379,7 +382,8 @@
     "try:\n",
     "    product_summary, product_competitors = await run_client(\"IBM's Match Chat AI assistant for Wimbledon\")\n",
     "except Exception as e:\n",
-    "    print(f\"Client error: {e}\")"
+    "    print(f\"Client error: {e}\")\n",
+    "    raise\n"
    ]
   },
   {
@@ -413,8 +417,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "stop_server()          \n",
-    "server_thread.join()   \n",
+    "stop_server()\n",
+    "server_thread.join()\n",
     "print(\"Server shutdown complete.\")"
    ]
   },


### PR DESCRIPTION
For some reason an old version of docling was selected which caused an error during execution.

We also change to use uv for past pip install.

## PR Checklist

### GitHub

- [x] **Commits signed**: All commits must be GPG or SSH signed.
- [x] **DCO Compliance**: Developer Certificate of Origin (DCO) applies to the code, documentation, and any example data provided. Ensure commits are signed off.
