### PR TITLE
Update model terminology in RAG with Langchain documentation

### DIFF
--- a/recipes/RAG/RAG_with_Langchain.ipynb
+++ b/recipes/RAG/RAG_with_Langchain.ipynb
@@ -164,7 +164,7 @@
     "### Choose your LLM\n",
     "The LLM will be used for answering the question, given the retrieved text.\n",
     "\n",
-    "Select a Granite Code model from the [`ibm-granite`](https://replicate.com/ibm-granite) org on Replicate. Here we use the Replicate Langchain client to connect to the model.\n",
+    "Select a Granite language model from the [`ibm-granite`](https://replicate.com/ibm-granite) org on Replicate. Here we use the Replicate Langchain client to connect to the model.\n",
     "\n",
     "To connect to a model on a provider other than Replicate, substitute this code cell with one from the [LLM component recipe](https://github.com/ibm-granite-community/granite-kitchen/blob/main/recipes/Components/Langchain_LLMs.ipynb)."
    ]


### PR DESCRIPTION
# Summary

Updates documentation text to use more accurate terminology when referring to Granite models in the RAG with Langchain notebook.

# Files Changed

📄 `recipes/RAG/RAG_with_Langchain.ipynb`

Changed the description from "Granite Code model" to "Granite language model" to more accurately reflect the type of model being used in the RAG (Retrieval-Augmented Generation) tutorial. This terminology update provides clearer guidance for users selecting models from the ibm-granite organization on Replicate.