### PR TITLE
Remove guardian on watsonx recipe from CI

### DIFF
--- a/.github/notebook_lists/vanilla_notebooks.txt
+++ b/.github/notebook_lists/vanilla_notebooks.txt
@@ -14,7 +14,6 @@ recipes/Granite_Guardian/HAP.ipynb
 recipes/Granite_Guardian/Granite_Guardian_Quick_Start.ipynb
 recipes/Granite_Guardian/Granite_Guardian_Detailed_Guide.ipynb
 recipes/Granite_Guardian/Granite_Guardian_Usage_Governance_Workflow.ipynb
-recipes/Granite_Guardian/Granite_Guardian_Watsonx_Usage.ipynb
 recipes/AI-Agents/travel_planner_agent.ipynb
 recipes/Evaluation/Unitxt_Quick_Start.ipynb
 recipes/Evaluation/Unitxt_Demo_Strategies.ipynb


### PR DESCRIPTION
The ibm/granite-guardian-3-8b model is deprecated on Watsonx and will
soon be removed. The recipe is currently failing in the nightly build.

Signed-off-by: BJ Hargrave <hargrave@us.ibm.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>